### PR TITLE
feat(OWRLD-39): Add user name from OAuth profile

### DIFF
--- a/backend/alembic/versions/20260310_1520_add_name_to_users.py
+++ b/backend/alembic/versions/20260310_1520_add_name_to_users.py
@@ -1,0 +1,33 @@
+"""Add name column to users table for OAuth profile data.
+
+Revision ID: 20260310_1520
+Revises: 20260308_1615
+Create Date: 2026-03-10 15:20:00.000000
+
+Related: GitHub issue #6 - Get user first name from Google OAuth
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers
+revision: str = "20260310_1520"
+down_revision: Union[str, None] = "20260308_1615"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add name column to users table."""
+    op.add_column(
+        "users",
+        sa.Column("name", sa.String(255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove name column from users table."""
+    op.drop_column("users", "name")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -25,6 +25,9 @@ class User(Base):
     # Email authentication
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     password_hash: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    
+    # User profile
+    name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
 
     # OAuth2 authentication
     oauth_provider: Mapped[Optional[str]] = mapped_column(

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -59,6 +59,7 @@ class UserResponse(BaseModel):
 
     id: int = Field(..., description="User ID")
     email: str = Field(..., description="User email address")
+    name: Optional[str] = Field(None, description="User's display name from OAuth or profile")
     is_verified: bool = Field(..., description="Whether user email is verified")
     is_premium: bool = Field(..., description="Whether user has premium subscription")
     created_at: datetime = Field(..., description="Account creation timestamp")

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -541,6 +541,7 @@ class AuthService:
         """
         user = User(
             email=user_info.email,
+            name=user_info.name,  # Store name from OAuth provider
             password_hash=None,  # OAuth users don't have passwords
             oauth_provider=user_info.provider.value,
             oauth_id=user_info.provider_user_id,


### PR DESCRIPTION
## Problem

Currently, the backend derives user names from email addresses (e.g., `first.last@domain.com` → `first.last`), which produces non-user-friendly display names.

## Solution

Store and return the actual name from OAuth providers (Google already provides this via the `profile` scope).

## Changes

### Backend
- ✅ Added `name` column to User model (nullable, String(255))
- ✅ Updated `_create_oauth_user` to store `user_info.name`
- ✅ Added `name` field to `UserResponse` schema
- ✅ Created migration `20260310_1520_add_name_to_users`

### Backward Compatibility
- ✅ Nullable field — existing users will have `null` name
- ✅ OAuth already requests `profile` scope (no config change needed)
- ✅ API change is non-breaking (new optional field)

## Testing
- [ ] Apply migration: `alembic upgrade head`
- [ ] Test OAuth signup flow (should populate name)
- [ ] Verify `/auth/me` returns name for OAuth users
- [ ] Verify existing users still work (null name)

## Acceptance Criteria
- [x] `name` field added to users table
- [x] OAuth signup stores `user.name`
- [x] `/me` endpoint returns `name`
- [x] Backward compatible (null for existing users)

---

Closes #6  
Closes OWRLD-39